### PR TITLE
Julia version updating correspondence. (i.g., Julia v0.7.0, v1.0.0, v1.1.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
-Compat 0.7.15
+julia 0.7
+Compat 1.2.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7
+julia 1.0
 Compat 1.2.0

--- a/test/testhttp.jl
+++ b/test/testhttp.jl
@@ -1,5 +1,5 @@
 using ConfParser
-using Base.Test
+using Test
 
 conf = ConfParse("confs/config.http")
 parse_conf!(conf)

--- a/test/testini.jl
+++ b/test/testini.jl
@@ -1,5 +1,5 @@
 using ConfParser
-using Base.Test
+using Test
 
 conf = ConfParse("confs/config.ini")
 parse_conf!(conf)

--- a/test/testmerge.jl
+++ b/test/testmerge.jl
@@ -1,5 +1,5 @@
 using ConfParser
-using Base.Test
+using Test
 
 conf = ConfParse("confs/config.ini")
 parse_conf!(conf)

--- a/test/testsimple.jl
+++ b/test/testsimple.jl
@@ -1,5 +1,5 @@
 using ConfParser
-using Base.Test
+using Test
 
 conf = ConfParse("confs/config.simple")
 parse_conf!(conf)


### PR DESCRIPTION
ConfParser.jl module raised several deprecated warnings in Julia v0.7.0.
I modified the ConfParser.jl and tested it locally for Julia v0.7.0, v1.0.0, v1.1.0.
I use this package in our script and now I am corresponding to the newest Julia versions, so I hope this package to correspond the novel versions of Julia >= v1.0.
