### PR TITLE
Allow INI keys that don't end in word characters.

### DIFF
--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -167,7 +167,7 @@ function parse_ini(s::ConfParse)
         end
 
         # parse key/value
-        m = match(r"^\s*([^=]*\w)\s*=\s*(.*)\s*$", line)
+        m = match(r"^\s*([^=]*[^\s])\s*=\s*(.*)\s*$", line)
         if (m != nothing)
             key::String, values::String = m.captures
             if (!haskey(s._data, blockname))

--- a/test/confs/config.ini
+++ b/test/confs/config.ini
@@ -5,6 +5,7 @@ header=leheader
 user=dbuser
 password=abc123
 host=localhost
+speed of light (m/s) = 3e8
 
 ; this is another comment
 [foobarness]

--- a/test/testini.jl
+++ b/test/testini.jl
@@ -6,6 +6,7 @@ parse_conf!(conf)
 
 @test retrieve(conf, "database", "user") == "dbuser"
 @test retrieve(conf, "database", "password") == "abc123"
+@test retrieve(conf, "database", "speed of light (m/s)") == "3e8"
 @test commit!(conf, "default", "database", "newuser") == true
 @test erase!(conf, "foobarness") == true
 save!(conf, "confs/out.conf")


### PR DESCRIPTION
I was having trouble with config keys that end in parenthesis. Tweaking the regex a bit seems to do the trick.