### PR TITLE
Convert all block names to lower case for ini file lookups.

### DIFF
--- a/src/ConfParser.jl
+++ b/src/ConfParser.jl
@@ -244,7 +244,7 @@ end
 Remove entry from ini block.
 """
 function erase!(s::ConfParse, block::String, key::String)
-    block_key = getkey(s._data, block, nothing)
+    block_key = getkey(s._data, lowercase(block), nothing)
     if block_key !== nothing
         if haskey(s._data[block_key], key)
             delete!(s._data[block_key], key)
@@ -309,7 +309,7 @@ end
 Retrieve data from an ini config file block.
 """
 function retrieve(s::ConfParse, block::String, key::String)
-    k = s._data[block][key]
+    k = s._data[lowercase(block)][key]
     length(k) == 1 ? first(k) : k
 end
 
@@ -329,7 +329,7 @@ end
 Retrieve data from an ini config file block and converting to type.
 """
 function retrieve(s::ConfParse, block::String, key::String, t::Type)
-    k = s._data[block][key]
+    k = s._data[lowercase(block)][key]
     parse(t, length(k) == 1 ? first(k) : k)
 end
 
@@ -352,8 +352,8 @@ function commit!(s::ConfParse, block::String, key::String, values::String)
     if s._syntax != "ini"
         throw(ArgumentError("invalid setter function called for syntax type: $(s._syntax)"))
     end
-    s._data[block][key] = [values]
-    s._is_modified      = true
+    s._data[lowercase(block)][key] = [values]
+    s._is_modified                 = true
 end
 
 """
@@ -384,6 +384,6 @@ haskey(s::ConfParse, key::String) = haskey(s._data, key)
 
 Check if a key exists inside an ini file block.
 """
-haskey(s::ConfParse, block::String, key::String) = haskey(s._data, block) && haskey(s._data[block], key)
+haskey(s::ConfParse, block::String, key::String) = haskey(s._data, lowercase(block)) && haskey(s._data[lowercase(block)], key)
 
 end # module ConfParser

--- a/test/confs/config.ini
+++ b/test/confs/config.ini
@@ -12,3 +12,6 @@ speed of light (m/s) = 3e8
 foo=bar,foo
 foobar=barfoo
 
+[Case]
+bar=foo
+bye=bye

--- a/test/testini.jl
+++ b/test/testini.jl
@@ -12,6 +12,12 @@ parse_conf!(conf)
 @test haskey(conf, "database", "user") == true
 @test haskey(conf, "database", "nothere") == false
 @test haskey(conf, "nothere", "foo") == false
+@test retrieve(conf, "Database", "user") == "dbuser"
+@test retrieve(conf, "Case", "bar") == "foo"
+@test erase!(conf, "Case", "bye")
+@test_throws KeyError retrieve(conf, "Case", "bye")
+@test haskey(conf, "Case", "bar") == true
+@test haskey(conf, "case", "bar") == true
 save!(conf, joinpath(@__DIR__, "confs", "out.conf"))
 
 # validate new conf write


### PR DESCRIPTION
A fix for #23 that handles the haskey methods as well.